### PR TITLE
intern the release script

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,8 +8,32 @@ permissions: {}
 
 jobs:
   build:
-    uses: thepwagner-org/actions/.github/workflows/golang-release-attest.yaml@github-attestations
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
       attestations: write
+    steps:
+      - name: "🌎 Fetching code"
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          persist-credentials: false
+      - name: "🌎 Setup Go"
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version-file: go.mod
+      - name: "📦 Release"
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
+        with:
+          version: v1.25.1
+          args: release --clean --parallelism=1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "🔏 Sign .deb"
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+        with:
+          subject-path: "dist/*.deb"
+      - name: "🔏 Sign .tar.gz"
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+        with:
+          subject-path: "dist/*.tar.gz"


### PR DESCRIPTION
I'm seeing

```
 $ gh attestation verify ghcr-reaper_0.0.1_linux_amd64.deb -o thepwagner
Loaded digest sha256:f1250d410cb32b3a5203885791c571fde4d239e1b2cc7f44f0ff552502a02aaa for file://ghcr-reaper_0.0.1_linux_amd64.deb
Loaded 1 attestation from GitHub API
✗ Verification failed

Error: verifying with issuer "sigstore.dev": failed to verify certificate identity: no matching certificate identity found
```

I'm pretty sure the reusable workflow name is being used as the SAN, so that's breaking the way the `gh` command is trying to verify the certificate identity:

<img width="1096" alt="Screenshot 2024-05-03 at 8 55 52 PM" src="https://github.com/thepwagner/ghcr-reaper/assets/1559510/65e3ebc9-f57e-47bf-a1b5-c443a9b98ee9">
